### PR TITLE
Properly list attached volumes

### DIFF
--- a/ec2/filters.go
+++ b/ec2/filters.go
@@ -42,7 +42,7 @@ func inVpc(vpc string) *ec2.Filter {
 
 func withInstanceId(id string) *ec2.Filter {
 	return &ec2.Filter{
-		Name: aws.String("tag:spinup:instanceid"),
+		Name: aws.String("attachment.instance-id"),
 		Values: aws.StringSlice(
 			[]string{id},
 		),

--- a/ec2/filters.go
+++ b/ec2/filters.go
@@ -42,7 +42,7 @@ func inVpc(vpc string) *ec2.Filter {
 
 func withInstanceId(id string) *ec2.Filter {
 	return &ec2.Filter{
-		Name: aws.String("attachment.instance-id"),
+		Name: aws.String("tag:spinup:instanceid"),
 		Values: aws.StringSlice(
 			[]string{id},
 		),

--- a/ec2/instances.go
+++ b/ec2/instances.go
@@ -140,13 +140,18 @@ func (e *Ec2) ListInstanceVolumes(ctx context.Context, id string) ([]string, err
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	log.Infof("getting snapshots for instance %s/%s", e.org, id)
+	log.Infof("getting volumes for instance %s/%s", e.org, id)
 
 	volumes := []string{}
 
 	input := ec2.DescribeVolumesInput{
 		Filters: []*ec2.Filter{
-			withInstanceId(id),
+			{
+				Name: aws.String("attachment.instance-id"),
+				Values: aws.StringSlice(
+					[]string{id},
+				),
+			},
 		},
 		MaxResults: aws.Int64(1000),
 	}
@@ -154,10 +159,10 @@ func (e *Ec2) ListInstanceVolumes(ctx context.Context, id string) ([]string, err
 	for {
 		out, err := e.Service.DescribeVolumesWithContext(ctx, &input)
 		if err != nil {
-			return nil, common.ErrCode("describing snapshots for volumes", err)
+			return nil, common.ErrCode("describing volumes for instance", err)
 		}
 
-		log.Debugf("got describe snapshots output %+v", out)
+		log.Debugf("got describe volumes output %+v", out)
 
 		for _, v := range out.Volumes {
 			volumes = append(volumes, aws.StringValue(v.VolumeId))


### PR DESCRIPTION
`withInstanceId` currently uses a tag which may not be set when we first create a server/volume, so better to use the attachment id here