### PR TITLE
Add list instance type offerings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data
 config/*config.json
+config/config*.json
 k8s/k8s-config.yaml
 vendor
 .vscode

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ GET /v2/ec2/metrics
 
 # Managing Instances
 GET /v2/ec2/{account}/instances
+GET /v2/ec2/{account}/instances/types
 GET /v2/ec2/{account}/instances/{id}
 GET /v2/ec2/{account}/instances/{id}/volumes
 GET /v2/ec2/{account}/instances/{id}/volumes/{vid}

--- a/api/routes.go
+++ b/api/routes.go
@@ -33,6 +33,7 @@ func (s *server) routes() {
 
 	// instance endpoints
 	api.HandleFunc("/{account}/instances", s.InstanceListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/instances/types", s.InstanceListTypeOfferings).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/instances/{id}", s.InstanceGetHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/instances/{id}/volumes", s.InstanceVolumesHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/instances/{id}/volumes/{vid}", s.InstanceVolumesHandler).Methods(http.MethodGet)


### PR DESCRIPTION
Adds a new route located at /{account}/instances/types that will return all the instance sizes for a given set of availability zones